### PR TITLE
Prevent host lookup on websocket connection

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -1719,7 +1719,7 @@ func (nc *Conn) createConn() (err error) {
 	hosts := []string{}
 	u := nc.current.url
 
-	if net.ParseIP(u.Hostname()) == nil {
+	if !nc.ws && net.ParseIP(u.Hostname()) == nil {
 		addrs, _ := net.LookupHost(u.Hostname())
 		for _, addr := range addrs {
 			hosts = append(hosts, net.JoinHostPort(addr, u.Port()))


### PR DESCRIPTION
We don't need to resolve the IP in websocket connections because the websocket protocol operates at a higher level of abstraction than traditional network connections and uses a URL, not an IP address, to establish a connection.